### PR TITLE
Feature/v0.2.0 preparations

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -53,7 +53,7 @@ jobs:
       - name: "Post code coverage data to Coveralls"
         uses: coverallsapp/github-action@v2
         with:
-          flag-name: run-${{ join(matrix.*, '-') }}
+          flag-name: coverage-${{ join(matrix.*, '-') }}
           parallel: true
 
   finish:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,6 +34,8 @@ jobs:
           python-version: ${{ matrix.python-version }}
           cache: "pip"
           cache-dependency-path: pyproject.toml
+
+      - name: "Install dependencies"
         run: |
           python -m pip install --upgrade pip
           pip install -e .

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,44 +1,65 @@
-name: ci
+name: CI
 
-on:
-  push:
-    branches: [ "main" ]
-  pull_request:
-    branches: [ "main" ]
+on: ["push", "pull_request"]
 
 permissions:
   contents: read
 
 jobs:
-  build:
+  test:
+    name: "Python ${{ matrix.python-version }} on ${{ matrix.os }}"
+    runs-on: "${{ matrix.os }}"
 
-    runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        os:
+          - ubuntu-latest
+          - macos-latest
+          - windows-latest
+        python-version:
+          - "3.9"
+          - "3.10"
+          - "3.11"
+          - "3.12"
+          - "3.13"
 
     steps:
-      - uses: actions/checkout@v3
-      - name: Set up Python
-        uses: actions/setup-python@v4
+      - name: "Check out the repository"
+        uses: actions/checkout@v4
+
+      - name: "Set up Python ${{ matrix.python-version }}"
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
           cache: "pip"
           cache-dependency-path: pyproject.toml
-      - uses: actions/cache@v3
-        id: cache
-        with:
-          path: ${{ env.pythonLocation }}
-          key: ${{ runner.os }}-python-${{ env.pythonLocation }}-${{ hashFiles('pyproject.toml') }}-test-v03
-      - name: Install Dependencies
-        if: steps.cache.outputs.cache-hit != 'true'
         run: |
           python -m pip install --upgrade pip
           pip install -e .
           pip install -r requirements-dev.txt
-      - name: run pytest py${{ matrix.python-version }}
-        run: |
-          make test
-      - name: run tox codestyle
-        run: |
-          make check-codestyle
+
+      - name: "Check codestyle"
+        run: make check-codestyle
+
+      - name: "Run type checker"
+        run: make check-types
+
+      - name: "Run tests & coverage"
+        run: make test
+
+      - name: "Post code coverage data to Coveralls"
+        uses: coverallsapp/github-action@v2
+        with:
+          flag-name: run-${{ join(matrix.*, '-') }}
+          parallel: true
+
+  finish:
+    needs: test
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Coveralls Finished"
+        uses: coverallsapp/github-action@v2
+        with:
+          parallel-finished: true

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,16 +1,14 @@
-name: Publish to pypi
+name: Publish release to pypi
 
 on:
   release:
-    types: [created]
+    types: [ created ]
 
 permissions:
   contents: read
 
 jobs:
-  deploy:
-    name: Publish release to PyPI
-
+  publish:
     runs-on: ubuntu-latest
 
     environment:
@@ -21,16 +19,21 @@ jobs:
       id-token: write
 
     steps:
-      - uses: actions/checkout@v4
-      - name: Set up Python
-        uses: actions/setup-python@v4
+      - name: "Check out the repository"
+        uses: actions/checkout@v4
+
+      - name: "Set up Python"
+        uses: actions/setup-python@v5
         with:
           python-version: "3.x"
-      - name: Install dependencies
+
+      - name: "Install dependencies"
         run: |
           python -m pip install --upgrade pip
           pip install build
-      - name: Build package
+
+      - name: "Build package"
         run: python -m build
-      - name: Publish package
+
+      - name: "Publish package"
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,13 @@
 test:
-	pytest cupyd/tests/ -v -ra
+	pytest cupyd/tests/ -v -ra --cov=cupyd/core
 
 check-codestyle:
-	flake8 --max-line-length 100
-	black . --line-length 100 --check
+	flake8
+	black . --check
 
 style:
-	flake8 --max-line-length 100
-	black . --line-length 100
+	flake8
+	black .
+
+check-types:
+	mypy cupyd

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 ![PyPI - Version](https://img.shields.io/pypi/v/cupyd)
 ![Python Version from PEP 621 TOML](https://img.shields.io/python/required-version-toml?tomlFilePath=https%3A%2F%2Fraw.githubusercontent.com%2Fjalorub%2Fcupyd%2Frefs%2Fheads%2Fmain%2Fpyproject.toml&style=flat-square)
 ![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/jalorub/cupyd/ci.yaml?style=flat-square)
+[![Coverage Status](https://coveralls.io/repos/github/jalorub/cupyd/badge.svg)](https://coveralls.io/github/jalorub/cupyd)
 ![PyPI - Downloads](https://img.shields.io/pypi/dm/cupyd?style=flat-square&link=https%3A%2F%2Fpypistats.org%2Fpackages%2Fcupyd)
 
                                                       __     

--- a/README.md
+++ b/README.md
@@ -1,4 +1,10 @@
 # cupyd
+
+![PyPI - Version](https://img.shields.io/pypi/v/cupyd)
+![Python Version from PEP 621 TOML](https://img.shields.io/python/required-version-toml?tomlFilePath=https%3A%2F%2Fraw.githubusercontent.com%2Fjalorub%2Fcupyd%2Frefs%2Fheads%2Fmain%2Fpyproject.toml&style=flat-square)
+![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/jalorub/cupyd/ci.yaml?style=flat-square)
+![PyPI - Downloads](https://img.shields.io/pypi/dm/cupyd?style=flat-square&link=https%3A%2F%2Fpypistats.org%2Fpackages%2Fcupyd)
+
                                                       __     
                                                      /\ \    
       ___       __  __      _____       __  __       \_\ \   
@@ -21,18 +27,18 @@ Python framework to create your own ETLs.
     - Python >= 3.9
 - Lightweight:
     - No dependencies for its core version.
-    - API version will require [Falcon](https://falcon.readthedocs.io/en/stable/index.html), which
-      is a minimalist ASGI/WSGI framework that doesn't require other packages to work.
-    - The Dashboard (full) version will require Falcon and [Dash](https://dash.plotly.com/).
+    - [WIP] API version will require [Falcon](https://falcon.readthedocs.io/en/stable/index.html),
+      which is a minimalist ASGI/WSGI framework that doesn't require other packages to work.
+    - [WIP] The Dashboard (full) version will require Falcon and [Dash](https://dash.plotly.com/).
 
 ## Usage
 
-In this example we will compute the factorial of 10.000 integers, using multiprocessing,
-while storing the results into 2 separate lists, one of even results and another for odd ones.
+In this example we will compute the factorial of 20.000 integers, using multiprocessing,
+while storing the results into 2 separate lists, one for even values and another for odd values.
 
 ``` py title="basic_etl.py"
 import math
-from typing import Any
+from typing import Any, Iterator
 
 from cupyd import ETL, Extractor, Transformer, Loader, Filter
 
@@ -43,10 +49,10 @@ class IntegerExtractor(Extractor):
         super().__init__()
         self.total_items = total_items
 
-        # generated integers will be passed onto each worker in buckets of size 10
+        # generated integers will be passed to the workers in buckets of size 10
         self.configuration.bucket_size = 10
 
-    def extract(self) -> int:
+    def extract(self) -> Iterator[int]:
         for item in range(self.total_items):
             yield item
 
@@ -85,7 +91,7 @@ class ListLoader(Loader):
 
 if __name__ == "__main__":
     # 1. Define the ETL Nodes
-    ext = IntegerExtractor(total_items=10_000)
+    ext = IntegerExtractor(total_items=20_000)
     factorial = Factorial()
     even_only = EvenOnly()
     odd_only = OddOnly()

--- a/cupyd/core/communication/interruption_handler.py
+++ b/cupyd/core/communication/interruption_handler.py
@@ -2,6 +2,7 @@ import ctypes
 import logging
 import signal
 from multiprocessing import Lock, Value
+from typing import Dict, Union, Callable, no_type_check
 
 from cupyd.core.communication.event_flag import InterProcessEventFlag
 
@@ -16,8 +17,9 @@ class InterruptionHandler:
         self._lock = Lock()
         self._stop_event = stop_event
         self._interrupted = Value(ctypes.c_bool, False)
-        self._original_signal_handlers = {}
+        self._original_signal_handlers: Dict[int, Union[Callable, int]] = {}
 
+    @no_type_check
     def start(self):
         self._original_signal_handlers[signal.SIGINT] = signal.signal(
             signal.SIGINT, self._handle_signal

--- a/cupyd/core/computing/etl_worker.py
+++ b/cupyd/core/computing/etl_worker.py
@@ -3,7 +3,7 @@ from multiprocessing import Process
 from multiprocessing import Queue as MultiprocessingQueue
 from queue import Queue
 from threading import Thread
-from typing import List, Dict, Type
+from typing import List, Dict, Type, Tuple
 
 from cupyd.core.communication import (
     Connector,
@@ -64,7 +64,7 @@ class ETLWorker:
             self.interruption_handler.start()
 
         thread_by_node_id: Dict[str, NodeWorker] = {}
-        finished_threads_queue = Queue()
+        finished_threads_queue: Queue[Tuple[str, NodeException]] = Queue()
 
         # start IntraProcessConnectors (InterProcessConnectors were started outside the ETLWorker)
         for connector in self.input_connector_by_node_id.values():

--- a/cupyd/core/computing/node_worker.py
+++ b/cupyd/core/computing/node_worker.py
@@ -206,7 +206,7 @@ class ExtractorWorker(NodeWorker):
     def _run(self):
         self.node: Extractor
 
-        bucket = []
+        bucket: List[Any] = []
         stop_iteration = False
         start_time: Optional[float] = None
         bucket_size = self.node.configuration.bucket_size
@@ -347,6 +347,8 @@ class ProcessorWorker(NodeWorker):
 class BulkerWorker(NodeWorker):
 
     def _run(self):
+        self.node: Bulker
+
         bulk = []
         bulk_size = self.node.bulk_size  # TODO: allow changing bulk size dynamically?
 
@@ -398,7 +400,7 @@ class BulkerWorker(NodeWorker):
                 self._handle_exception(exception=e, action=PRODUCE_BUCKET)
 
     @staticmethod
-    def _chunk(items: List[Any], bulk_size: int) -> List[Any]:
+    def _chunk(items: List[Any], bulk_size: int) -> Iterator[List[Any]]:
         for i in range(0, len(items), bulk_size):
             yield items[i : i + bulk_size]  # noqa
 

--- a/cupyd/core/etl.py
+++ b/cupyd/core/etl.py
@@ -3,7 +3,7 @@ from collections import defaultdict
 from copy import deepcopy
 from multiprocessing import Queue, set_start_method, get_start_method
 from time import time
-from typing import List, Dict, Optional
+from typing import List, Dict, Optional, Union, Tuple, no_type_check
 
 from cupyd.core.communication.connector import (
     Connector,
@@ -221,6 +221,8 @@ class ETL:
                 if target.id in segment.node_ids:
                     target_segment = segment
 
+            connector: Union[IntraProcessConnector, InterProcessConnector]
+
             # TODO: allow customizing these max sizes when configuring the ETL/Nodes
             if origin_segment.id == target_segment.id:
                 connector = IntraProcessConnector(maxsize=0)
@@ -237,9 +239,8 @@ class ETL:
                 )
 
         # 5. Create necessary structures & ETL Workers
-        worker_num = 1
-        finished_workers = Queue()
-        node_timings = Queue(maxsize=100_000)  # todo: might cause slowdowns, rethink?
+        finished_workers: Queue[Tuple[str, str, Dict[str, NodeException]]] = Queue()
+        node_timings: Queue[Tuple[str, float]] = Queue(maxsize=100_000)
         stop_event = InterProcessEventFlag()
         pause_event = InterProcessEventFlag()
         interruption_handler = InterruptionHandler(stop_event=stop_event)
@@ -250,13 +251,13 @@ class ETL:
             node.id: InterProcessEventFlag(start_set=monitor_performance) for node in nodes
         }
         segments_by_id: Dict[str, ETLSegment] = {}
+        etl_worker_num = 1
 
         for segment in segments:
             worker_class = ETLWorkerThread if segment.run_in_main_process else ETLWorkerProcess
 
             for _ in range(segment.num_workers):
-                etl_worker_id = f"etl_worker_{worker_num}"
-
+                etl_worker_id = f"etl_worker_{etl_worker_num}"
                 etl_worker = worker_class(
                     worker_id=etl_worker_id,
                     segment_id=segment.id,
@@ -278,8 +279,8 @@ class ETL:
                     node_timings=node_timings,
                     finished_workers=finished_workers,
                 )
-                segment.workers_by_id[etl_worker_id] = etl_worker
-                worker_num += 1
+                segment.workers_by_id[etl_worker_id] = etl_worker  # type: ignore
+                etl_worker_num += 1
 
             segments_by_id[segment.id] = segment
 
@@ -296,13 +297,14 @@ class ETL:
         )
 
     @staticmethod
-    def _setup_logger() -> [logging.Formatter, int, Optional[str]]:
+    @no_type_check
+    def _setup_logger() -> Tuple[Optional[logging.Formatter], Optional[int], Optional[str]]:
         """Update the current logger handler & backup the current logging configuration."""
 
         try:
             current_formatter = deepcopy(logging.root.handlers[0].formatter)
-        except Exception:
-            logger.warning("Unable to get current logger")
+        except Exception as e:
+            logger.warning(f"Unable to get current logger: {e}")
             return None, None, None
 
         current_level = logging.root.level

--- a/cupyd/core/etl.py
+++ b/cupyd/core/etl.py
@@ -225,9 +225,9 @@ class ETL:
 
             # TODO: allow customizing these max sizes when configuring the ETL/Nodes
             if origin_segment.id == target_segment.id:
-                connector = IntraProcessConnector(maxsize=0)
+                connector = IntraProcessConnector()
             else:
-                connector = InterProcessConnector(maxsize=0)
+                connector = InterProcessConnector()
                 connector.start()
 
             input_connector_by_node_id[target.id] = connector
@@ -240,7 +240,7 @@ class ETL:
 
         # 5. Create necessary structures & ETL Workers
         finished_workers: Queue[Tuple[str, str, Dict[str, NodeException]]] = Queue()
-        node_timings: Queue[Tuple[str, float]] = Queue(maxsize=100_000)
+        node_timings: Queue[Tuple[str, float]] = Queue(maxsize=25_000)
         stop_event = InterProcessEventFlag()
         pause_event = InterProcessEventFlag()
         interruption_handler = InterruptionHandler(stop_event=stop_event)

--- a/cupyd/core/graph/algorithms.py
+++ b/cupyd/core/graph/algorithms.py
@@ -12,8 +12,8 @@ from cupyd.core.nodes import Extractor, Transformer, Loader, Filter, Bulker, DeB
 
 
 def topological_sort(root_node: Node) -> Tuple[List[Node], List[Edge]]:
-    nodes = []
-    edges = []
+    nodes: List[Node] = []
+    edges: List[Edge] = []
 
     # if the graph contains cycles (not a DAG), it will fail when computing the topological sort.
     nodes, edges = _downstream_discovery(root_node, nodes, edges)
@@ -25,8 +25,8 @@ def assign_names_and_ids_to_nodes(nodes: List[Node]) -> None:
     """If a Node doesn't have a name provide it one using the class name with a numbered suffix."""
 
     node_id = 1
-    num_nodes_per_class = defaultdict(int)
-    last_num_per_class = defaultdict(int)
+    num_nodes_per_class: defaultdict[str, int] = defaultdict(int)
+    last_num_per_class: defaultdict[str, int] = defaultdict(int)
 
     for node in nodes:
         node.id = f"node_{node_id}"
@@ -52,7 +52,7 @@ def get_etl_segments(nodes: List[Node], num_workers: int) -> List[ETLSegment]:
 
     for group in _split_nodes_by_attr(nodes=nodes, attr_name="run_in_main_process"):
         for group_ in _split_nodes_if_not_consecutive(nodes=group):
-            run_in_main_process = group_[0].configuration.run_in_main_process
+            run_in_main_process = group_[0].configuration.run_in_main_process  # type: ignore
 
             if run_in_main_process or isinstance(group_[0], Extractor):
                 segment_num_workers = 1
@@ -194,8 +194,8 @@ def _split_nodes_if_not_consecutive(nodes: List[Node]) -> List[List[Node]]:
 
 
 def _get_node_attr(
-    node: typing.Union[Extractor, Transformer, Loader, Filter, Bulker, DeBulker],
+    node: typing.Union[Node, Extractor, Transformer, Loader, Filter, Bulker, DeBulker],
     attr_name: str,
     default: typing.Any = None,
 ):
-    return getattr(node.configuration, attr_name, default)
+    return getattr(node.configuration, attr_name, default)  # type: ignore

--- a/cupyd/core/graph/classes.py
+++ b/cupyd/core/graph/classes.py
@@ -46,7 +46,7 @@ class Node(_Connectable):
         return str(self)
 
     @final
-    def __rshift__(self, target: Union[_Connectable, Iterable[_Connectable]]) -> SubGraph:
+    def __rshift__(self, target: Union[_Connectable, List[_Connectable]]) -> SubGraph:
         return _NodeConnector.connect(origin=self, target=target)
 
     def start(self):
@@ -127,6 +127,8 @@ class Edge:
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, Edge):
             return (self.origin == other.origin) and (self.target == other.target)
+        else:
+            raise TypeError(f"Comparison error between edge and {type(other)}")
 
     def __str__(self) -> str:
         return f"{self.origin} ⇒ {self.target}"
@@ -151,7 +153,7 @@ class SubGraph(_Connectable):
         self.root_node = root_node
         self.leaf_nodes = tuple(node for node in leaf_nodes) if leaf_nodes else ()
 
-    def __rshift__(self, target: Union[_Connectable, Iterable[_Connectable]]) -> SubGraph:
+    def __rshift__(self, target: Union[_Connectable, List[_Connectable]]) -> SubGraph:
         origin = self.leaf_nodes or self.root_node
 
         if isinstance(origin, tuple):
@@ -170,7 +172,7 @@ class SubGraph(_Connectable):
 class _NodeConnector:
 
     @classmethod
-    def connect(cls, origin: Node, target: Union[_Connectable, Iterable[_Connectable]]) -> SubGraph:
+    def connect(cls, origin: Node, target: Union[_Connectable, List[_Connectable]]) -> SubGraph:
         """Connect a list of Nodes to one of the following Connectable:
 
         a) Another Node.
@@ -215,7 +217,7 @@ class _NodeConnector:
             target_leaf_nodes = [target]
         elif isinstance(target, SubGraph):
             target_root_nodes = [target.root_node]
-            target_leaf_nodes = target.leaf_nodes or [target.root_node]
+            target_leaf_nodes = list(target.leaf_nodes) or [target.root_node]
         else:
             raise TypeError(f"Cannot connect to a {type(target)} target object.")
 

--- a/cupyd/core/stats/timings_buffer.py
+++ b/cupyd/core/stats/timings_buffer.py
@@ -8,7 +8,7 @@ class TimingsBuffer:
     def __init__(self, maxsize: int = 25):
         super().__init__()
         self._maxsize = maxsize
-        self._queue = SimpleQueue()
+        self._queue: SimpleQueue = SimpleQueue()
         self._buffer_size = Value("i", 0)
 
     def produce_timing(self, timing: float):

--- a/cupyd/examples/readme_etl.py
+++ b/cupyd/examples/readme_etl.py
@@ -1,10 +1,10 @@
-"""In this example we will compute the factorial of 50.000 integers, using multiprocessing,
-while storing the results into 2 separate lists, one of even results and another for odd ones."""
+"""In this example we will compute the factorial of 20.000 integers, using multiprocessing,
+while storing the results into 2 separate lists, one for even values and another for odd values."""
 
 import math
 import logging
 from time import time
-from typing import Any
+from typing import Any, Iterator
 
 from cupyd import ETL, Extractor, Transformer, Loader, Filter
 
@@ -20,7 +20,7 @@ class IntegerExtractor(Extractor):
         # generated integers will be passed onto each worker in buckets of size 10
         self.configuration.bucket_size = 10
 
-    def extract(self) -> int:
+    def extract(self) -> Iterator[int]:
         for item in range(self.total_items):
             yield item
 
@@ -65,7 +65,7 @@ def compute_with_single_process():
 
     logger.info("Running README script without cupyd...")
 
-    for value in range(10_000):
+    for value in range(20_000):
         result = math.factorial(value)
         if result & 1:
             even_results.append(factorial)
@@ -77,7 +77,7 @@ def compute_with_single_process():
 
 if __name__ == "__main__":
     # 1. Instantiate the ETL Nodes
-    ext = IntegerExtractor(total_items=10_000)
+    ext = IntegerExtractor(total_items=20_000)
     factorial = Factorial()
     even_only = EvenOnly()
     odd_only = OddOnly()

--- a/cupyd/examples/readme_etl.py
+++ b/cupyd/examples/readme_etl.py
@@ -4,7 +4,7 @@ while storing the results into 2 separate lists, one for even values and another
 import math
 import logging
 from time import time
-from typing import Any, Iterator
+from typing import Any, Iterator, Optional
 
 from cupyd import ETL, Extractor, Transformer, Loader, Filter
 
@@ -33,13 +33,13 @@ class Factorial(Transformer):
 
 class EvenOnly(Filter):
 
-    def filter(self, item: int) -> int | None:
+    def filter(self, item: int) -> Optional[int]:
         return item if item & 1 else None
 
 
 class OddOnly(Filter):
 
-    def filter(self, item: int) -> int | None:
+    def filter(self, item: int) -> Optional[int]:
         return None if item & 1 else item
 
 

--- a/cupyd/tests/graph/conftest.py
+++ b/cupyd/tests/graph/conftest.py
@@ -4,7 +4,7 @@ from cupyd.core.graph.classes import Node
 
 
 @fixture(scope="function", autouse=True)
-def node_a() -> Node:
+def node_a():
     node = Node()
     node.name = "A"
     yield node
@@ -63,11 +63,4 @@ def node_h():
 def node_i():
     node = Node()
     node.name = "i"
-    yield node
-
-
-@fixture(scope="function", autouse=True)
-def node_j():
-    node = Node()
-    node.name = "J"
     yield node

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,30 +4,44 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "cupyd"
-version = '0.1.0'
+dynamic = ["version"]
+dependencies = []
+requires-python = ">=3.9"
+description = "Python framework to easily build ETLs."
+readme = "README.md"
+license = { text = "MIT" }
 authors = [
     { name = "Francisco Javier Alonso Rubio", email = "fjalorub@gmail.com" },
 ]
-description = "Python-only framework to easily build ETLs."
-readme = "README.md"
-requires-python = ">=3.9"
-keywords = ["python", "cupyd", "data", "etl", "parallelism", "multiprocessing", "framework"]
-license = { text = "MIT" }
+keywords = [
+    "python", "data", "etl", "parallelism", "multiprocessing", "framework", "concurrency",
+    "threading"
+]
 classifiers = [
     "Programming Language :: Python :: 3",
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
+    "Intended Audience :: Developers",
+    "Topic :: Software Development :: Libraries :: Application Frameworks",
+    "Development Status :: 3 - Alpha",
 ]
-dependencies = []
+
+[project.urls]
+Repository = "https://github.com/jalorub/cupyd.git"
 
 [tool.setuptools.packages.find]
 include = ["cupyd*"]
 exclude = ["tests*"]
 
-[project.optional-dependencies]
-api = []
-full = []
-
 [tool.black]
 line-length = 100
-target-version = ["py39", "py310", "py311", "py312"]
+target-version = ["py39", "py310", "py311", "py312", "py313"]
+
+[tool.flake8]
+max-line-length = 100
+exclude = [".git", ".github", "__pycache__", "*venv*", "*.venv*"]
+
+[tool.mypy]
+no_strict_optional = true
+ignore_missing_imports = true
+check_untyped_defs = true

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,6 @@
 pytest>=8,<9
-mkdocs-material>=9.4.0
 flake8>=7,<8
 black>=24,<25
+mypy>=1.11,<2
+pytest-cov
+flake8-pyproject


### PR DESCRIPTION
- Add mypy to project & fix issues found by it
- Centralize all flake8, black & mypy config into pyproject.toml
- Improve CI workflow: add mypy, add multiple OS to matrix, upload coverage
- Add support to python 3.13
- Remove MKDocs dependency since it's not being used
- Improve project metadata inside pyproject.toml (website, dynamic version)
- Improve README.md: add badges, some text improvements. One of the badges shows the num of pypi downloads, taken from here https://pypistats.org/packages/cupyd
- Compute tests coverage & upload to Coveralls. See https://coveralls.io/github/jalorub/cupyd
- Fix issue with macOS when creating Queue with maxsize bigger than allowed at Sempahore (OS dependant limit). In the case of macOS, its 32768. If the user tries to create a Queue bigger than the allowed OS size, limit it with a warning